### PR TITLE
docs: Fix simple typo, vitual -> virtual

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ make venv
 virtualenv -p python3 ./env
 ```
 
-### Make sure you activate your vitual environment!!
+### Make sure you activate your virtual environment!!
 
 ```bash
 


### PR DESCRIPTION
There is a small typo in README.md.

Should read `virtual` rather than `vitual`.

