### PR TITLE
docs: fix simple typo, recomend -> recommend

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Getting Started
 git clone https://github.com/eddyekofo94/pyramidVue.git
 ```
 
-## First create a virtual environment, otherwise by default python instance available will be used (I recomend the former).
+## First create a virtual environment, otherwise by default python instance available will be used (I recommend the former).
 
 ```bash
 make venv


### PR DESCRIPTION
There is a small typo in README.md.

Should read `recommend` rather than `recomend`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md